### PR TITLE
fix: V3 适配补丁 — JSON 容错、代理绕过、turn 计数、DB 写入修复

### DIFF
--- a/scrivai/agents/auditor.py
+++ b/scrivai/agents/auditor.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from govdoc.pipelines.output_utils import relaxed_json_loads
+
 from pydantic import BaseModel, ValidationError
 
 from scrivai.pes.base import BasePES
-from scrivai.utils import relaxed_json_loads
 
 if TYPE_CHECKING:
     from scrivai.models.pes import PESRun, PhaseConfig, PhaseResult
@@ -65,10 +66,8 @@ class AuditorPES(BasePES):
             raise FileNotFoundError(f"AuditorPES summarize 阶段 output.json 未生成: {output_path}")
 
         try:
-            data = relaxed_json_loads(
-                output_path.read_text(encoding="utf-8"), strict=self.config.strict_json
-            )
-        except json.JSONDecodeError as e:
+            data = relaxed_json_loads(output_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError) as e:
             raise ValueError(f"output.json 不是合法 JSON: {e}") from e
 
         try:
@@ -89,14 +88,22 @@ class AuditorPES(BasePES):
             if not isinstance(finding, dict):
                 raise ValueError(f"findings[{idx}] 必须是对象")
             verdict = finding.get("verdict")
-            if verdict not in verdict_levels:
+            verdict_str = verdict.get("verdict") if isinstance(verdict, dict) else verdict
+            if verdict_str not in verdict_levels:
                 raise ValueError(
-                    f"findings[{idx}].verdict={verdict!r} 不在 verdict_levels={verdict_levels}"
+                    f"findings[{idx}].verdict={verdict_str!r} 不在 verdict_levels={verdict_levels}"
                 )
             if evidence_required:
-                evidence = finding.get("evidence") or []
-                if not isinstance(evidence, list) or len(evidence) == 0:
-                    raise ValueError(f"findings[{idx}] 缺少 evidence(evidence_required=True)")
+                evidence_quotes = (
+                    verdict.get("evidence_quotes") if isinstance(verdict, dict) else []
+                ) or []
+                evidence_refs = finding.get("evidence_refs") or []
+                has_quotes = isinstance(evidence_quotes, list) and len(evidence_quotes) > 0
+                has_refs = isinstance(evidence_refs, list) and len(evidence_refs) > 0
+                if not has_quotes and not has_refs:
+                    raise ValueError(
+                        f"findings[{idx}] 缺少 evidence(evidence_required=True)"
+                    )
 
         run.final_output = validated.model_dump()
         run.final_output_path = output_path
@@ -119,10 +126,8 @@ class AuditorPES(BasePES):
             raise ValueError(f"AuditorPES 需要业务层预置 data/checkpoints.json(未找到: {cp_path})")
 
         try:
-            checkpoints = relaxed_json_loads(
-                cp_path.read_text(encoding="utf-8"), strict=self.config.strict_json
-            )
-        except json.JSONDecodeError as e:
+            checkpoints = relaxed_json_loads(cp_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError) as e:
             raise ValueError(f"data/checkpoints.json 不是合法 JSON: {e}") from e
 
         if not isinstance(checkpoints, list):
@@ -138,3 +143,19 @@ class AuditorPES(BasePES):
         missing = expected_ids - actual_ids
         if missing:
             raise ValueError(f"未覆盖的 checkpoint id: {sorted(missing)}")
+
+        # Fix findings files with Chinese quotes / bad JSON written by the model
+        if findings_dir.exists():
+            for fp in findings_dir.glob("*.json"):
+                raw = fp.read_text(encoding="utf-8")
+                try:
+                    json.loads(raw)
+                except (json.JSONDecodeError, ValueError):
+                    try:
+                        fixed = relaxed_json_loads(raw)
+                        fp.write_text(
+                            json.dumps(fixed, ensure_ascii=False, indent=2),
+                            encoding="utf-8",
+                        )
+                    except Exception:
+                        pass

--- a/scrivai/io/convert.py
+++ b/scrivai/io/convert.py
@@ -88,7 +88,7 @@ def pdf_to_markdown(
     path: str | Path,
     *,
     base_url: str = "http://100.81.95.44:7861",
-    timeout: int = 120,
+    timeout: int = 300,
 ) -> str:
     """MonkeyOCR HTTP 服务把 PDF 转 markdown。
 
@@ -113,10 +113,14 @@ def pdf_to_markdown(
 
     base = base_url.rstrip("/")
 
+    # MonkeyOCR 通常是内网服务，绕过系统代理
+    session = requests.Session()
+    session.trust_env = False
+
     try:
         with src.open("rb") as f:
             files = {"file": (src.name, f, "application/pdf")}
-            resp = requests.post(f"{base}/parse", files=files, timeout=timeout)
+            resp = session.post(f"{base}/parse", files=files, timeout=timeout)
     except requests.exceptions.RequestException as e:
         raise IOError(f"MonkeyOCR 网络请求失败({base}):{e}") from e
 
@@ -133,7 +137,7 @@ def pdf_to_markdown(
     full_url = f"{base}{download_url}" if download_url.startswith("/") else download_url
 
     try:
-        zip_resp = requests.get(full_url, timeout=timeout)
+        zip_resp = session.get(full_url, timeout=timeout)
     except requests.exceptions.RequestException as e:
         raise IOError(f"MonkeyOCR 下载 ZIP 失败({full_url}):{e}") from e
 

--- a/scrivai/pes/llm_client.py
+++ b/scrivai/pes/llm_client.py
@@ -248,6 +248,7 @@ class LLMClient:
         turns: list[PhaseTurn] = []
         pending_tool_calls: dict[str, dict[str, Any]] = {}
         result_response: LLMResponse | None = None
+        assistant_turn_count = 0
 
         async for message in query(prompt=prompt, options=options):
             if isinstance(message, AssistantMessage):
@@ -256,6 +257,11 @@ class LLMClient:
                     turns.append(turn)
                     if on_turn:
                         on_turn(turn)
+                # SDK 在 permission_mode=default 下不把被拒工具计入 max_turns，
+                # 这里自己计数所有 assistant turn，超出即中断。
+                assistant_turn_count += 1
+                if assistant_turn_count > max_turns:
+                    raise _MaxTurnsError(assistant_turn_count)
 
             elif isinstance(message, UserMessage):
                 turn = self._parse_user_turn(message, len(turns), pending_tool_calls)

--- a/scrivai/trajectory/store.py
+++ b/scrivai/trajectory/store.py
@@ -153,7 +153,7 @@ class TrajectoryStore:
     ) -> None:
         """写入 runs 表新行,status='running',started_at=now。"""
         sql = """
-            INSERT INTO runs (run_id, pes_name, model_name, provider, sdk_version,
+            INSERT OR REPLACE INTO runs (run_id, pes_name, model_name, provider, sdk_version,
                               skills_git_hash, agents_git_hash, skills_is_dirty,
                               status, task_prompt, runtime_context, started_at)
             VALUES (?,?,?,?,?,?,?,?,'running',?,?,?)
@@ -237,6 +237,41 @@ class TrajectoryStore:
         )
         return rec
 
+    def delete_run(self, run_id: str) -> None:
+        """删除 run 及其关联的 phases/turns/tool_calls/feedback。"""
+
+        def _work(conn: sqlite3.Connection) -> None:
+            phase_ids = [
+                row[0]
+                for row in conn.execute(
+                    "SELECT phase_id FROM phases WHERE run_id=?", (run_id,)
+                ).fetchall()
+            ]
+            if phase_ids:
+                placeholders = ",".join("?" * len(phase_ids))
+                turn_ids = [
+                    row[0]
+                    for row in conn.execute(
+                        f"SELECT turn_id FROM turns WHERE phase_id IN ({placeholders})",
+                        phase_ids,
+                    ).fetchall()
+                ]
+                if turn_ids:
+                    tc_ph = ",".join("?" * len(turn_ids))
+                    conn.execute(
+                        f"DELETE FROM tool_calls WHERE turn_id IN ({tc_ph})", turn_ids
+                    )
+                    conn.execute(
+                        f"DELETE FROM turns WHERE turn_id IN ({tc_ph})", turn_ids
+                    )
+                conn.execute(
+                    f"DELETE FROM phases WHERE phase_id IN ({placeholders})", phase_ids
+                )
+            conn.execute("DELETE FROM feedback WHERE run_id=?", (run_id,))
+            conn.execute("DELETE FROM runs WHERE run_id=?", (run_id,))
+
+        self._execute_with_retry(_work)
+
     def list_runs(
         self,
         pes_name: str | None = None,
@@ -277,9 +312,9 @@ class TrajectoryStore:
         phase_order: int,
         attempt_no: int,
     ) -> int:
-        """插入 phases 行(started_at=now),返回新 phase_id;UNIQUE 冲突直接抛 IntegrityError。"""
+        """插入 phases 行(started_at=now),返回新 phase_id;UNIQUE 冲突时替换旧行。"""
         sql = """
-            INSERT INTO phases (run_id, phase_name, phase_order, attempt_no, started_at)
+            INSERT OR REPLACE INTO phases (run_id, phase_name, phase_order, attempt_no, started_at)
             VALUES (?,?,?,?,?)
         """
         params = (run_id, phase_name, phase_order, attempt_no, _utcnow_iso())


### PR DESCRIPTION
1. agents/auditor.py — 审核结果解析容错                                                                                                                            
                                                                                                                                                                     
  - 引入 relaxed_json_loads：替代标准 json.loads，能处理中文引号等不规范的 JSON                                                                                      
  - verdict 结构兼容：原来 verdict 是字符串，现在兼容了 dict 形式（如 {"verdict": "pass", "evidence_quotes": [...]}）                                                
  - evidence 验证放宽：不再只看 evidence 字段，新增支持 evidence_quotes 和 evidence_refs，有任一即可                                                                 
  - 自动修复坏 JSON：新增一段逻辑，遍历 findings 目录下所有 .json 文件，解析失败的自动用 relaxed_json_loads 修复后回写                                               
                                                                                                                                                                     
  2. io/convert.py — MonkeyOCR 代理和超时                                                                                                                            
                                                                                                                                                                     
  - 超时时间 120s → 300s：给 MonkeyOCR 解析更多时间                                                                                                                  
  - 绕过系统代理：新建 requests.Session() 并设置 trust_env = False，因为 MonkeyOCR 是内网服务，走代理会失败
                                                                                                                                                                     
  3. pes/llm_client.py — SDK turn 计数修复                                                                                                                           
                                                                                                                                                                     
  - 新增 assistant turn 计数：SDK 在 permission_mode=default 下不把被拒工具调用计入 max_turns，你手动计数所有 assistant turn，超出即抛 _MaxTurnsError，防止无限循环  
  
  4. trajectory/store.py — 数据库写入和删除                                                                                                                          
  
  - INSERT OR REPLACE：runs 和 phases 表的插入从 INSERT 改为 INSERT OR REPLACE，解决重复写入时的唯一约束冲突                                                         
  - 新增 delete_run() 方法：删除一个 run 及其关联的 phases → turns → tool_calls → feedback，级联清理